### PR TITLE
upgraded module for python3 support (still compatible w/ python2.X)

### DIFF
--- a/library/_openshift.py
+++ b/library/_openshift.py
@@ -264,10 +264,10 @@ class OpenshiftRemoteTask(object):
         """
 
         def is_list(u):
-                return isinstance(u, list)
+            return isinstance(u, list)
 
         def is_dict(u):
-                return isinstance(u, dict)
+            return isinstance(u, dict)
 
         if c_ansible == c_live:
             # Does small work of scalar types, including None; and if

--- a/library/_openshift.py
+++ b/library/_openshift.py
@@ -1,5 +1,4 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#!/usr/bin/python # -*- coding: utf-8 -*-
 
 """Back-end (remote) half of the "openshift" action plugin."""
 
@@ -8,6 +7,7 @@
 
 import json
 import types
+import sys
 
 from ansible.module_utils.basic import AnsibleModule
 try:
@@ -265,10 +265,16 @@ class OpenshiftRemoteTask(object):
         """
 
         def is_list(u):
-            return isinstance(u, types.ListType)
+            if (sys.version_info >= (3,0)):
+                return isinstance(u, list)
+            else:
+                return isinstance(u, types.ListType)
 
         def is_dict(u):
-            return isinstance(u, types.DictType)
+            if (sys.version_info >= (3,0)):
+                return isinstance(u, dict)
+            else:
+                return isinstance(u, types.DictType)
 
         if c_ansible == c_live:
             # Does small work of scalar types, including None; and if

--- a/library/_openshift.py
+++ b/library/_openshift.py
@@ -6,7 +6,6 @@
 # Polytechnique Fédérale de Lausanne; see ../LICENSE
 
 import json
-import types
 import sys
 
 from ansible.module_utils.basic import AnsibleModule
@@ -265,16 +264,10 @@ class OpenshiftRemoteTask(object):
         """
 
         def is_list(u):
-            if (sys.version_info >= (3,0)):
                 return isinstance(u, list)
-            else:
-                return isinstance(u, types.ListType)
 
         def is_dict(u):
-            if (sys.version_info >= (3,0)):
                 return isinstance(u, dict)
-            else:
-                return isinstance(u, types.DictType)
 
         if c_ansible == c_live:
             # Does small work of scalar types, including None; and if


### PR DESCRIPTION
Types module is absent in python 3 libs, used standard types instead (ie. types.ListType -> list)
Imported sys module to check python version and keep retrocompatibility with 2.x