### PR TITLE
Privilege flags

### DIFF
--- a/action_plugins/openshift.py
+++ b/action_plugins/openshift.py
@@ -86,11 +86,11 @@ options:
     default: 0
     description:
       - Indicates the level of verbosity of logging by oc.
-  as_admin:
+  as_user:
     required: false
-    default: false
+    default: null
     descriprtion:
-      - A flag to indicate admin impersonation for privileged actions on the kubernete cluster (ie. create a custom PersistentVolume)
+      - A string to indicate user impersonation for specific actions on the kubernete cluster
   state:
     required: false
     choices: ['present', 'absent', 'latest', 'reloaded', 'stopped']
@@ -158,7 +158,7 @@ class ActionModule(ActionBase):
     # These arguments are for passing to the _openshift remote task;
     # they make no sense to Kubernetes.
     REMOTE_ARGS = set(['state', 'oc', 'label', 'server',
-                       'force', 'all', 'log_level', 'name', 'namespace', 'as_admin'])
+                       'force', 'all', 'log_level', 'name', 'namespace', 'as_user'])
 
     def run(self, tmp=None, task_vars=None):
         self.__result = super(ActionModule, self).run(tmp, task_vars)

--- a/action_plugins/openshift.py
+++ b/action_plugins/openshift.py
@@ -86,6 +86,11 @@ options:
     default: 0
     description:
       - Indicates the level of verbosity of logging by oc.
+  as_admin:
+    required: false
+    default: false
+    descriprtion:
+      - A flag to indicate admin impersonation for privileged actions on the kubernete cluster (ie. create a custom PersistentVolume)
   state:
     required: false
     choices: ['present', 'absent', 'latest', 'reloaded', 'stopped']
@@ -153,7 +158,7 @@ class ActionModule(ActionBase):
     # These arguments are for passing to the _openshift remote task;
     # they make no sense to Kubernetes.
     REMOTE_ARGS = set(['state', 'oc', 'label', 'server',
-                       'force', 'all', 'log_level', 'name', 'namespace'])
+                       'force', 'all', 'log_level', 'name', 'namespace', 'as_admin'])
 
     def run(self, tmp=None, task_vars=None):
         self.__result = super(ActionModule, self).run(tmp, task_vars)

--- a/library/_openshift.py
+++ b/library/_openshift.py
@@ -32,6 +32,7 @@ class OpenshiftRemoteTask(object):
             all=dict(default=False, type='bool'),
             log_level=dict(default=0, type='int'),
             state=dict(default='present', choices=['present', 'absent', 'latest', 'reloaded', 'stopped']),
+            as_admin=dict(default=False, type='bool'),
         ),
         mutually_exclusive=[['filename', 'content']])
 
@@ -59,6 +60,7 @@ class OpenshiftRemoteTask(object):
         self.content = self.module.params.get('content', None)
         self.kind = self.module.params.get('kind')
         self.label = self.module.params.get('label')
+        self.as_admin=self.module.params.get('as_admin')
 
     def run(self):
         state = self.module.params.get('state')
@@ -105,6 +107,8 @@ class OpenshiftRemoteTask(object):
 
         if force:
             cmd.append('--force')
+        if self.as_admin:
+            cmd.append('--as=system:admin')
 
         if self.content is not None:
             cmd.extend(['-f', '-'])
@@ -140,6 +144,8 @@ class OpenshiftRemoteTask(object):
 
         if force:
             cmd.append('--force')
+        if self.as_admin:
+            cmd.append('--as=system:admin')
 
         if self.content is not None:
             cmd.extend(['-f', '-'])
@@ -176,6 +182,8 @@ class OpenshiftRemoteTask(object):
 
             if self.force:
                 cmd.append('--ignore-not-found')
+            if self.as_admin:
+                cmd.append('--as=system:admin')
 
         return self._execute(cmd)
 
@@ -197,6 +205,9 @@ class OpenshiftRemoteTask(object):
 
             if self.all:
                 cmd.append('--all-namespaces')
+            if self.as_admin:
+                cmd.append('--as=system:admin')
+
 
         return cmd
 
@@ -230,6 +241,9 @@ class OpenshiftRemoteTask(object):
 
             if self.force:
                 cmd.append('--ignore-not-found')
+            if self.as_admin:
+                cmd.append('--as=system:admin')
+
 
         return self._execute(cmd)
 

--- a/library/_openshift.py
+++ b/library/_openshift.py
@@ -279,16 +279,10 @@ class OpenshiftRemoteTask(object):
         """
 
         def is_list(u):
-            if (sys.version_info >= (3,0)):
-                return isinstance(u, list)
-            else:
-                return isinstance(u, types.ListType)
+            return isinstance(u, types.ListType)
 
         def is_dict(u):
-            if (sys.version_info >= (3,0)):
-                return isinstance(u, dict)
-            else:
-                return isinstance(u, types.DictType)
+            return isinstance(u, types.DictType)
 
         if c_ansible == c_live:
             # Does small work of scalar types, including None; and if

--- a/library/_openshift.py
+++ b/library/_openshift.py
@@ -32,7 +32,7 @@ class OpenshiftRemoteTask(object):
             all=dict(default=False, type='bool'),
             log_level=dict(default=0, type='int'),
             state=dict(default='present', choices=['present', 'absent', 'latest', 'reloaded', 'stopped']),
-            as_admin=dict(default=False, type='bool'),
+            as_user=dict( type='str'),
         ),
         mutually_exclusive=[['filename', 'content']])
 
@@ -60,7 +60,7 @@ class OpenshiftRemoteTask(object):
         self.content = self.module.params.get('content', None)
         self.kind = self.module.params.get('kind')
         self.label = self.module.params.get('label')
-        self.as_admin=self.module.params.get('as_admin')
+        self.as_user=self.module.params.get('as_user')
 
     def run(self):
         state = self.module.params.get('state')
@@ -144,8 +144,8 @@ class OpenshiftRemoteTask(object):
 
         if force:
             cmd.append('--force')
-        if self.as_admin:
-            cmd.append('--as=system:admin')
+        if self.as_user is not None:
+            cmd.append('--as='+ self.as_user)
 
         if self.content is not None:
             cmd.extend(['-f', '-'])
@@ -182,8 +182,8 @@ class OpenshiftRemoteTask(object):
 
             if self.force:
                 cmd.append('--ignore-not-found')
-            if self.as_admin:
-                cmd.append('--as=system:admin')
+            if self.as_user is not None:
+                cmd.append('--as='+ self.as_user)
 
         return self._execute(cmd)
 
@@ -205,8 +205,8 @@ class OpenshiftRemoteTask(object):
 
             if self.all:
                 cmd.append('--all-namespaces')
-            if self.as_admin:
-                cmd.append('--as=system:admin')
+            if self.as_user is not None:
+                cmd.append('--as='+ self.as_user)
 
 
         return cmd
@@ -241,8 +241,8 @@ class OpenshiftRemoteTask(object):
 
             if self.force:
                 cmd.append('--ignore-not-found')
-            if self.as_admin:
-                cmd.append('--as=system:admin')
+            if self.as_user is not None:
+                cmd.append('--as='+ self.as_user)
 
 
         return self._execute(cmd)

--- a/library/_openshift.py
+++ b/library/_openshift.py
@@ -1,5 +1,4 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#!/usr/bin/python # -*- coding: utf-8 -*-
 
 """Back-end (remote) half of the "openshift" action plugin."""
 
@@ -8,6 +7,7 @@
 
 import json
 import types
+import sys
 
 from ansible.module_utils.basic import AnsibleModule
 try:
@@ -265,10 +265,16 @@ class OpenshiftRemoteTask(object):
         """
 
         def is_list(u):
-            return isinstance(u, types.ListType)
+            if (sys.version_info >= (3,0)):
+                return isinstance(u, list)
+            else:
+                return isinstance(u, types.ListType)
 
         def is_dict(u):
-            return isinstance(u, types.DictType)
+            if (sys.version_info >= (3,0)):
+                return isinstance(u, dict)
+            else:
+                return isinstance(u, types.DictType)
 
         if c_ansible == c_live:
             # Does small work of scalar types, including None; and if


### PR DESCRIPTION
Added an 'as_admin' boolean flag to be able to create kubernete objects that require system:admin impersonation (similar to a sudo command for oc) like retreiving volume informations and creating volume links withing the cluster linked to specific deployments