### PR TITLE
[feature] Proper --check and --diff support

### DIFF
--- a/library/_openshift.py
+++ b/library/_openshift.py
@@ -144,7 +144,7 @@ class OpenshiftRemoteTask(object):
             # As per https://github.com/kubernetes/kubernetes/issues/70674,
             # updates that don't specify a metadata.resourceVersion undergo some
             # kind of hazard of being rejected (depending on whether they have ever been
-            # edited with something `kubectl apply` or `oc apply`, IIUC).
+            # edited with something like `kubectl apply` or `oc apply`, IIUC).
             # So add a metadata.resourceVersion if we can find one.
             if 'metadata' in current_state and 'resourceVersion' in current_state['metadata']:
                 resource_version = current_state['metadata']['resourceVersion']

--- a/library/_openshift.py
+++ b/library/_openshift.py
@@ -98,7 +98,7 @@ class OpenshiftRemoteTask(object):
         rc, out, err = self.module.run_command(args)
         return rc == 0
 
-    def create(self, check=True):
+    def create(self):
         if self.exists():
             return
 

--- a/library/_openshift.py
+++ b/library/_openshift.py
@@ -73,8 +73,6 @@ class OpenshiftRemoteTask(object):
             self.delete()
         elif state == 'reloaded':
             self.replace()
-        elif state == 'stopped':
-            self.stop()
         elif state == 'latest':
             self.replace()
         else:
@@ -239,38 +237,7 @@ class OpenshiftRemoteTask(object):
     def exists(self):
         return self._execute_nofail(['get', '--no-headers'] + self._get_oc_flags())
 
-    # TODO: This is currently unused, perhaps convert to 'scale' with a replicas param?
-    def stop(self):
 
-        if not self.force and not self.exists():
-            return 
-
-        cmd = ['stop']
-
-        if self.filename:
-            cmd.append('--filename=' + ','.join(self.filename))
-        else:
-            if not self.kind:
-                raise AnsibleError('resource required to stop without filename')
-
-            cmd.append(self.kind)
-
-            if self.name:
-                cmd.append(self.name)
-
-            if self.label:
-                cmd.append('--selector=' + self.label)
-
-            if self.all:
-                cmd.append('--all')
-
-            if self.force:
-                cmd.append('--ignore-not-found')
-            if self.as_user is not None:
-                cmd.append('--as='+ self.as_user)
-
-
-        return self._execute(cmd)
 
     def _find_diff_points(self, c_ansible, c_live, path=[]):
         """Enumerate all points where `c_ansible` is *not* a superset of `c_live`.


### PR DESCRIPTION
- Use Ansible's `--diff` mechanism, instead of re-inventing our own. `-v` is no longer necessary to see the diffs; nice, minified diffs are shown with meaningful headers indicating where in the Kubernetes object's structure a diff was found.
- Refactor and adapt for `--check` support. When activated, the call to `oc apply` (which now happens in a single place in the source code) is short-circuited; the rest of the module's behavior works as usual (including diff extraction)
